### PR TITLE
Explicitly set chromedriver port

### DIFF
--- a/src/Drivers/Chrome.php
+++ b/src/Drivers/Chrome.php
@@ -17,7 +17,7 @@ class Chrome implements DriverContract
 
     public function open(): void
     {
-        static::startChromeDriver();
+        static::startChromeDriver(['--port=9515']);
     }
 
     public function close(): void


### PR DESCRIPTION
Chrome version 128 doesn't have a default port 9515 so dusk fails to connect to it.

See: https://github.com/laravel/dusk/pull/1124